### PR TITLE
fix(typings): thread status enum needs to be preserved at runtime

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -31,11 +31,11 @@ export type HWND = Buffer;
  * These aren't typos on our end, backend sends this, I can probably look at it later; still, is C.
  * Workaround via enum, do not use these values directly.
  */
-export enum OverlayThreadStatus {
-  Starting = 'starting',
-  Running = 'runing',
-  Stopping = 'stopping',
-  Destroyed = 'destoyed',
+export const enum OverlayThreadStatus {
+  Starting = 'starting ',
+  Running = 'runing ',
+  Stopping = 'stopping ',
+  Destroyed = 'destoyed ',
 }
 
 /**


### PR DESCRIPTION
* Values get sent to the caller with a space at the end, adjust enum
accordingly so caller doesn't have to know about this, or run into
failed comparisons.
* Enum needs to be a `const enum` so values don't get erased at runtime.